### PR TITLE
fix: remove reference to tns-core-modules.d.ts from WebImageCache.d.ts

### DIFF
--- a/WebImageCache.d.ts
+++ b/WebImageCache.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../node_modules/tns-core-modules/tns-core-modules.d.ts" />
 import { View } from 'ui/core/view';
 
 export class WebImage extends View {


### PR DESCRIPTION
I made a small mistake in my last PR.

The path to `../../node_modules/tns-core-modules/tns-core-modules.d.ts` in `WebImageCache.d.ts` was wrong and TypeScript projects that use this plugin, should have the nativescript typings installed themselves.