### PR TITLE
Add some additional required installation steps to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Released under the MIT License, anybody can freely include this in any type of p
       initializeOnAngular();
      }
     }
+
+Next step is to register the module within your `app/main.ts` file right before the `bootstrapModule()` call:
+
+    import * as elementRegistryModule from 'nativescript-angular/element-registry';
+    elementRegistryModule.registerElement("WebImage", () => require("nativescript-web-image-cache").WebImage);
+
+    platformNativeScriptDynamic().bootstrapModule(AppModule);
+
 After initialisation, the markup tag `<WebImage></WebImage>` can be used in templates of components.
 
     <GridLayout rows='*' columns='*'>


### PR DESCRIPTION
For me the WebImage tag would not work correctly on iOS without registering the module in my main.ts file.