### PR TITLE
Bump SDWebImage to the latest version

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-	<!--Describe the permissions, features or other configurations required by your plugin for Android. 
-		To read more about android permissions go to https://developer.android.com/guide/topics/permissions/index.html -->
-	<!--EXAMPLE: uses-permission android:name="android.permission.INTERNET"/> -->
-
-</manifest>

--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -1,9 +1,0 @@
-# Android permissions and dependencies
-
-* (Optional) Use AndroidManifest.xml to describe any permissions, features or other configuration specifics required or used by your plugin for Android. 
-NOTE: The NativeScript CLI will not resolve any contradicting or duplicate entries during the merge. After the plugin is installed, you need to manually resolve such issues.
-
-* (Optional) Use include.gradle configuration to describe any native dependencies. If there are no such, this file can be removed. For more information, see the [include.gradle Specification](http://docs.nativescript.org/plugins/plugins#includegradle-specification)
-
-
-[Read more about nativescript plugins](http://docs.nativescript.org/plugins/plugins)

--- a/platforms/ios/Info.plist
+++ b/platforms/ios/Info.plist
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<!--Describe the permissions, features or other configurations required by your plugin for iOS.-->
-</dict>
-</plist>

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SDWebImage', '~> 3.7.6'
+pod 'SDWebImage', '~> 4.4'

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -1,9 +1,0 @@
-# iOS permissions and dependencies
-
-
-* (Optional) Use Info.plist to describe any permissions, features or other configuration specifics required or used by your plugin for iOS. 
-NOTE: The NativeScript CLI will not resolve any contradicting or duplicate entries during the merge. After the plugin is installed, you need to manually resolve such issues.
-* (Optional) Use build.xcconfig configuration to describe any plugin the native dependencies. If there are no such, this file can be removed. For more information, see the [build.xcconfig Specification section](http://docs.nativescript.org/plugins/plugins#buildxcconfig-specification).
-
-
-[Read more about nativescript plugins](http://docs.nativescript.org/plugins/plugins)

--- a/web-image-cache.ios.js
+++ b/web-image-cache.ios.js
@@ -133,7 +133,7 @@ exports.setCacheLimit = setCacheLimit;
 function clearCache() {
     var imageCache = SDImageCache.sharedImageCache();
     imageCache.clearMemory();
-    imageCache.clearDisk();
+    imageCache.clearDiskOnCompletion(() => {});
 }
 exports.clearCache = clearCache;
 function initializeOnAngular() {


### PR DESCRIPTION
SDWebImage 4.x seems to be more memory-friendly and it gets rid of a few deprecated API usage-related warnings.

I've also changed something in the JS file because it was breaking change in 4.x. You probably have at TS source for it actually (see #46) that need to be changed.

Also cleaned up some leftovers from the plugin seed this plugin doesn't need.