### PR TITLE
Redo #49 (bump SDWebImage to the latest version)

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-	<!--Describe the permissions, features or other configurations required by your plugin for Android. 
-		To read more about android permissions go to https://developer.android.com/guide/topics/permissions/index.html -->
-	<!--EXAMPLE: uses-permission android:name="android.permission.INTERNET"/> -->
-
-</manifest>

--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -1,9 +1,0 @@
-# Android permissions and dependencies
-
-* (Optional) Use AndroidManifest.xml to describe any permissions, features or other configuration specifics required or used by your plugin for Android. 
-NOTE: The NativeScript CLI will not resolve any contradicting or duplicate entries during the merge. After the plugin is installed, you need to manually resolve such issues.
-
-* (Optional) Use include.gradle configuration to describe any native dependencies. If there are no such, this file can be removed. For more information, see the [include.gradle Specification](http://docs.nativescript.org/plugins/plugins#includegradle-specification)
-
-
-[Read more about nativescript plugins](http://docs.nativescript.org/plugins/plugins)

--- a/platforms/ios/Info.plist
+++ b/platforms/ios/Info.plist
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<!--Describe the permissions, features or other configurations required by your plugin for iOS.-->
-</dict>
-</plist>

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SDWebImage', '~> 3.7.6'
+pod 'SDWebImage', '~> 4.4.1'

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -1,9 +1,0 @@
-# iOS permissions and dependencies
-
-
-* (Optional) Use Info.plist to describe any permissions, features or other configuration specifics required or used by your plugin for iOS. 
-NOTE: The NativeScript CLI will not resolve any contradicting or duplicate entries during the merge. After the plugin is installed, you need to manually resolve such issues.
-* (Optional) Use build.xcconfig configuration to describe any plugin the native dependencies. If there are no such, this file can be removed. For more information, see the [build.xcconfig Specification section](http://docs.nativescript.org/plugins/plugins#buildxcconfig-specification).
-
-
-[Read more about nativescript plugins](http://docs.nativescript.org/plugins/plugins)

--- a/web-image-cache.ios.js
+++ b/web-image-cache.ios.js
@@ -133,7 +133,7 @@ exports.setCacheLimit = setCacheLimit;
 function clearCache() {
     var imageCache = SDImageCache.sharedImageCache();
     imageCache.clearMemory();
-    imageCache.clearDisk();
+    imageCache.clearDiskOnCompletion(function() {});
 }
 exports.clearCache = clearCache;
 function initializeOnAngular() {

--- a/web-image-cache.ios.ts
+++ b/web-image-cache.ios.ts
@@ -199,7 +199,7 @@ export function setCacheLimit(numberOfDays) {
 export function clearCache() {
   let imageCache = SDImageCache.sharedImageCache();
   imageCache.clearMemory();
-  imageCache.clearDisk();
+  imageCache.clearDiskOnCompletion(() => {});
 }
 
 export function initializeOnAngular() {


### PR DESCRIPTION
This was done (and merged) in #49 but since then the TS sources have been added to the repo (thanks!) which somehow reverted the changes in PR #49, so here they are again:

SDWebImage 4.x seems to be more memory-friendly and it gets rid of a few deprecated API usage-related warnings.

I've also changed something in the TS/JS filse because it was breaking change in 4.x.

Also cleaned up some leftovers from the plugin seed this plugin doesn't need.